### PR TITLE
chore: externalize three

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,19 @@ The viewer is still a work in progress and subject to change. Please join the [D
 ## Installation
 
 `npm install --save icosa-viewer`
+
+### three.js peer dependency
+
+`gallery-viewer` expects [`three`](https://threejs.org/) to be provided by the consuming application. Load a compatible `three.js` version (>=0.165 <0.166.0) before importing the viewer. When using ES modules in the browser, supply an import map:
+
+```html
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/"
+  }
+}
+</script>
+```
+

--- a/dist/index.html
+++ b/dist/index.html
@@ -13,8 +13,8 @@
         <script type="importmap" class="es6_modules_map">
             {
                 "imports": {
-                    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.0/examples/jsm/",
-                    "three/examples/": "https://cdn.jsdelivr.net/npm/three@0.164.0/examples/"
+                    "three": "https://cdn.jsdelivr.net/npm/three@<version>/build/three.module.js",
+                    "three/addons/": "https://cdn.jsdelivr.net/npm/three@<version>/examples/jsm/"
                 }
             }
         </script>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Viewer for Tilt Brush / Open Brush files and derivatives",
   "scripts": {
     "watch": "parcel watch",
-    "build": "parcel build --no-cache"
+    "build": "parcel build --no-cache",
+    "test": "npm run build && node test.js"
   },
   "repository": {
     "type": "git",
@@ -19,7 +20,6 @@
   "targets": {
     "module": {
       "includeNodeModules": [
-        "three",
         "@depasquale/three-immersive-controls",
         "camera-controls",
         "three-icosa",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+
+const output = fs.readFileSync('dist/icosa-viewer.module.js', 'utf8');
+if (!output.includes('from "three"')) {
+  throw new Error('Bundled output is missing external three import');
+}
+console.log('three import verified');


### PR DESCRIPTION
## Summary
- mark `three` as an external by removing it from Parcel's include list
- add import map for `three` in dist example
- document that consumers must supply a compatible `three.js` version
- add a simple test that builds and checks for an external `three` import

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cc27957e4833199b52cbb8731e585